### PR TITLE
feat(firmware): p.o.c to sent an e-stop command to an ESP over HTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 .cache
 .clangd
+compile_commands.*

--- a/prototype/firmware/remote-e-stop/pio_extra.py
+++ b/prototype/firmware/remote-e-stop/pio_extra.py
@@ -1,0 +1,4 @@
+import os
+Import("env")
+
+env.Replace(COMPILATIONDB_INCLUDE_TOOLCHAIN=True) # Needed for clangd IDE integration

--- a/prototype/firmware/remote-e-stop/platformio.ini
+++ b/prototype/firmware/remote-e-stop/platformio.ini
@@ -1,0 +1,6 @@
+[env:espwroom32]
+platform = espressif32
+framework = arduino
+board = upesy_wroom
+monitor_speed = 115200
+extra_scripts = pre:pio_extra.py

--- a/prototype/firmware/remote-e-stop/readme.md
+++ b/prototype/firmware/remote-e-stop/readme.md
@@ -1,0 +1,19 @@
+The emergency stop (e-stop) is a panic button for cutting power to the robot's motors. It
+has both a physical button and can also be triggered digitally, for instance as a button on
+a remote controller. The physical and remote functionality are independent, so a software
+failure will not prevent the physical e-stop from working. 
+
+The e-stop makes use of a relay to switch the power circuit to the motor controller.
+A relay is like an electrically controlled switch, where a low-power signal can be used to
+switch a high-power circuit. The relay used is commonly open, single-pole double-throw.
+A single-pole single-throw would make more sense, but this is the one we have available in
+the lab. 
+
+The code in this folder is merely a proof-of-concept for the remote control functionality.
+When the `RELAY_INPUT_PIN` is set to LOW, the relay switches and interrupts the otherwise
+closed circuit. As a stand-in for a remote controller, the code features a tiny web server
+hosting a form. Using buttons on this form you can trigger or reset the e-stop.
+
+To access the form, flash an ESP with this code, open a serial connection on your PC and hit
+the reset button on the ESP. It will print the server's IP address over serial. The IP is
+only reachable when connected to the WiFi network hosted by the ESP.

--- a/prototype/firmware/remote-e-stop/src/main.cpp
+++ b/prototype/firmware/remote-e-stop/src/main.cpp
@@ -1,0 +1,83 @@
+#include <Arduino.h>
+#include <WebServer.h>
+#include <WiFi.h>
+
+// Wi-Fi credentials
+const char *ssid = "ESP32-Car";
+const char *password = "12345678";
+
+WebServer server(80);
+
+#define RELAY_INPUT_PIN 33
+
+void handleRoot();
+void handleCommand();
+void emergencyStop();
+void restart();
+
+void setup() {
+  pinMode(RELAY_INPUT_PIN, OUTPUT);
+  digitalWrite(RELAY_INPUT_PIN, HIGH);
+
+  Serial.begin(115200);
+
+  // Start Wi-Fi Access Point
+  WiFi.softAP(ssid, password);
+  Serial.print("IP Address: ");
+  Serial.println(WiFi.softAPIP());
+
+  // Define API routes
+  server.on("/", handleCommand);
+
+  server.begin();
+  Serial.println("Web server started");
+}
+
+void loop() { server.handleClient(); }
+
+// Serve the control page
+void sendFormResponse() {
+  server.send(200, "text/html", R"EOF(
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ESP32 Control</title>
+</head>
+<body>
+    <h1>ESP32 Car Control</h1>
+    <p>Send commands over HTTP: 192.168.4.1/do?command=[command]</p>
+    <p>Where [command] is one of:</p>
+    <ul>
+        <li>estop</li>
+        <li>restart</li>
+    </ul>
+    <a href="?command=estop"><button>EMERGENCY STOP</button></a>
+    <br><br>
+    <a href="?command=restart"><button>restart</button></a>
+</body>
+</html>
+)EOF");
+}
+
+// Process movement commands
+void handleCommand() {
+  if (server.hasArg("command")) {
+    String command = server.arg("command");
+    Serial.println("command: " + command);
+
+    if (command == "estop")
+      emergencyStop();
+    else if (command == "restart")
+      restart();
+    else {
+      server.send(400, "text/plain", "Incorrect `command` parameter");
+      return;
+    }
+  }
+
+  sendFormResponse();
+}
+
+void emergencyStop() { digitalWrite(RELAY_INPUT_PIN, LOW); }
+
+void restart() { digitalWrite(RELAY_INPUT_PIN, HIGH); }


### PR DESCRIPTION
Uses the ESP in Access Point mode and hosts a tiny web server with a single plain HTML form. Through this page you can send commands as URL query parameters, which will be handled by the ESP to control a CO-SPDT relay for switching the power of a circuit.

Documentation will follow.